### PR TITLE
Added xRotation and yRotation to JoystickPlugin to fully support Xbox One controller

### DIFF
--- a/FreePIE.Core.Plugins/JoystickPlugin.cs
+++ b/FreePIE.Core.Plugins/JoystickPlugin.cs
@@ -137,6 +137,16 @@ namespace FreePIE.Core.Plugins
             get { return State.Z;  }
         }
 
+        public int xRotation
+        {
+            get { return State.RotationX; }
+        }
+
+        public int yRotation
+        {
+            get { return State.RotationY; }
+        }
+
         public int zRotation
         {
             get { return State.RotationZ; }


### PR DESCRIPTION
The native PC driver for the Xbox One controller maps the right stick to rotation X and rotation Y, which is currently not exposed by the `JoystickPlugin`. This change adds those two properties, which are already supported by `SlimDX.DirectInput.JoystickState`, and has been tested with a real controller. The left stick, D-pad, buttons, triggers, and bumpers already work, too.

http://majornelson.com/2014/06/05/pc-drivers-for-the-xbox-one-controller-available-now/
