### PR TITLE
[hydra] Add AutoEnableHemisphereTracking

### DIFF
--- a/FreePIE.Core.Plugins/Hydra/Sixense.cs
+++ b/FreePIE.Core.Plugins/Hydra/Sixense.cs
@@ -80,5 +80,9 @@ namespace FreePIE.Core.Plugins.Hydra
         [DllImport("sixense.dll", SetLastError = false, EntryPoint = "sixenseGetNewestData",
             CallingConvention = CallingConvention.Cdecl)]
         public static extern int GetNewestData(int which, out ControllerData data);
+
+        [DllImport("sixense.dll", SetLastError = false, EntryPoint = "sixenseAutoEnableHemisphereTracking",
+            CallingConvention = CallingConvention.Cdecl)]
+        public static extern int AutoEnableHemisphereTracking(int which_controller);
     }
 }

--- a/FreePIE.Core.Plugins/HydraPlugin.cs
+++ b/FreePIE.Core.Plugins/HydraPlugin.cs
@@ -331,5 +331,10 @@ namespace FreePIE.Core.Plugins
             get { return plugin.Controller[index].is_docked == 1; }
             set { plugin.EmulatedData[index].IsDocked = (byte)(value ? 1 : 0); }
         }
+
+        public void enableHemisphereTracking()
+        {
+            Sixense.AutoEnableHemisphereTracking(index);
+        }
     }
 }


### PR DESCRIPTION
The Razer Hydra requires the user to point each controller at the base
station while this method called to enable proper tracking below the
hydra base station.

See documentation of `sixenseAutoEnableHemisphereTracking` for more
information.

A script initialization would be something like

```
if starting:
    diagnostics.debug("Please point both Hydra controllers at the base and press either trigger")
    initializing = True
if initializing:
    if True in [e.trigger == 1 for e in hydra]:
        for e in hydra: e.enableHemisphereTracking()
        initializing = False
        diagnostics.debug("Hydra initialized")
else:
    pass
```
