### PR TITLE
Fix FreeIMU COM support for Arduino Leonardo

### DIFF
--- a/FreePIE.Core.Plugins/ComDevicePlugin.cs
+++ b/FreePIE.Core.Plugins/ComDevicePlugin.cs
@@ -30,6 +30,7 @@ namespace FreePIE.Core.Plugins
             OnStarted(this, new EventArgs());
 
             serialPort = new SerialPort(port, baudRate);
+            serialPort.DtrEnable = true;
             serialPort.Open();
             Init(serialPort);
 


### PR DESCRIPTION
When using an Arduino Leonardo and FreeIMU, the serialPort.ReadLine() function blocks indefinitely. By enabling the Data Terminal Ready (DTR) signal, reads no longer block and the device functions as expected.

Personally encountered this issue, found fix thanks to http://forum.freetronics.com/viewtopic.php?t=5530