### PR TITLE
Frenchy62620 speech patch 1

### DIFF
--- a/FreePIE.Core.Plugins/SpeechPlugin.cs
+++ b/FreePIE.Core.Plugins/SpeechPlugin.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
 using System.Speech.Recognition;


### PR DESCRIPTION
Hi Anders
we could pilot the recognition of vocal command:

**speech.saidOff()**
stop the recognition  (return always false when the flag is activated)
except if a "start" command exists

**speech.saidON()**
restart the recognition

**speech.saidInitOnMsg("start micro")**
add a vocal "start" command to activate the recognition

**so the sample below is easy to understand:**

```
if starting:
    speech.saidInitOnMsg("start micro")

if speech.said("stop micro"):
    speech.say("micro stopping")
    speech.saidOff()

if speech.said("start micro"):
    speech.saidOn()
    speech.say("micro starting")    

if keyboard.getPressed(Key.H):
    speech.saidOn()
    speech.say("micro starting")

if speech.said("hello"):
    speech.say("hello")

```
