### PR TITLE
remove memory allocation in send loop

### DIFF
--- a/Lib/Android/FreePIE Android IMU/src/com/freepie/android/imu/MainActivity.java
+++ b/Lib/Android/FreePIE Android IMU/src/com/freepie/android/imu/MainActivity.java
@@ -83,6 +83,11 @@ public class MainActivity extends Activity {
     private TextView imu;
     private LinearLayout emptyLayout;
 
+    private float[] debug_imu = new float[3];
+    private float[] debug_acc = new float[3];
+    private float[] debug_mag = new float[3];
+    private float[] debug_gyr = new float[3];
+
     private TimerTask debugHandler = new TimerTask() {
         @Override
         public void run() {
@@ -90,13 +95,12 @@ public class MainActivity extends Activity {
                 @Override
                 public void run() {
                     if (udpSenderService != null) {
-                        float[] imu = new float[3], acc = new float[3], mag = new float[3], gyr = new float[3];
-                        String lastError = udpSenderService.debug(acc, mag, gyr, imu);
+                        String lastError = udpSenderService.debug(debug_acc, debug_mag, debug_gyr, debug_imu);
                         if (lastError != null)
                             error(lastError);
                         if (chkDebug.isChecked()) {
-                            debugImu(imu);
-                            debugRaw(acc, gyr, mag);
+                            debugImu(debug_imu);
+                            debugRaw(debug_acc, debug_gyr, debug_mag);
                         }
                     }
                 }

--- a/Lib/Android/FreePIE Android IMU/src/com/freepie/android/imu/MainActivity.java
+++ b/Lib/Android/FreePIE Android IMU/src/com/freepie/android/imu/MainActivity.java
@@ -182,7 +182,7 @@ public class MainActivity extends Activity {
 
         emptyLayout.requestFocus();
 
-        t.schedule(debugHandler, 100L, 100L);
+        t.schedule(debugHandler, 500L, 500L);
 
         bindService();
     }

--- a/Lib/Android/FreePIE Android IMU/src/com/freepie/android/imu/MainActivity.java
+++ b/Lib/Android/FreePIE Android IMU/src/com/freepie/android/imu/MainActivity.java
@@ -88,23 +88,25 @@ public class MainActivity extends Activity {
     private float[] debug_mag = new float[3];
     private float[] debug_gyr = new float[3];
 
+    private Runnable timer_task = new Runnable() {
+        @Override
+        public void run() {
+            if (udpSenderService != null) {
+                String lastError = udpSenderService.debug(debug_acc, debug_mag, debug_gyr, debug_imu);
+                if (lastError != null)
+                    error(lastError);
+                if (chkDebug.isChecked()) {
+                    debugImu(debug_imu);
+                    debugRaw(debug_acc, debug_gyr, debug_mag);
+                }
+            }
+        }
+    };
+
     private TimerTask debugHandler = new TimerTask() {
         @Override
         public void run() {
-            runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    if (udpSenderService != null) {
-                        String lastError = udpSenderService.debug(debug_acc, debug_mag, debug_gyr, debug_imu);
-                        if (lastError != null)
-                            error(lastError);
-                        if (chkDebug.isChecked()) {
-                            debugImu(debug_imu);
-                            debugRaw(debug_acc, debug_gyr, debug_mag);
-                        }
-                    }
-                }
-            });
+            runOnUiThread(timer_task);
         }
     };
 

--- a/Lib/Android/FreePIE Android IMU/src/com/freepie/android/imu/MainActivity.java
+++ b/Lib/Android/FreePIE Android IMU/src/com/freepie/android/imu/MainActivity.java
@@ -63,7 +63,6 @@ public class MainActivity extends Activity {
     private static final String SEND_ORIENTATION = "send_orientation";
     private static final String SEND_RAW = "send_raw";
     private static final String SAMPLE_RATE = "sample_rate";
-    private static final String DEBUG = "debug";
 
     private static final String DEBUG_FORMAT = "%.2f;%.2f;%.2f";
 
@@ -139,7 +138,7 @@ public class MainActivity extends Activity {
         txtPort.setText(preferences.getString(PORT, "5555"));
         chkSendOrientation.setChecked(preferences.getBoolean(SEND_ORIENTATION, true));
         chkSendRaw.setChecked(preferences.getBoolean(SEND_RAW, true));
-        chkDebug.setChecked(preferences.getBoolean(DEBUG, false));
+        chkDebug.setChecked(false);
         populateSampleRates(preferences.getInt(SAMPLE_RATE, 0));
         populateIndex(preferences.getInt(INDEX, 0));
 
@@ -263,7 +262,6 @@ public class MainActivity extends Activity {
                 .putBoolean(SEND_ORIENTATION, chkSendOrientation.isChecked())
                 .putBoolean(SEND_RAW, chkSendRaw.isChecked())
                 .putInt(SAMPLE_RATE, getSelectedSampleRateId())
-                .putBoolean(DEBUG, chkDebug.isChecked())
                 .commit();
     }
 

--- a/Lib/Android/FreePIE Android IMU/src/com/freepie/android/imu/MainActivity.java
+++ b/Lib/Android/FreePIE Android IMU/src/com/freepie/android/imu/MainActivity.java
@@ -266,8 +266,17 @@ public class MainActivity extends Activity {
     }
 
     @Override
+    protected void onPause() {
+        super.onPause();
+        chkDebug.setChecked(false);
+        setDebugVisibility(false);
+    }
+
+    @Override
     protected void onStop() {
         super.onStop();
+        chkDebug.setChecked(false);
+        setDebugVisibility(false);
         if (udpSenderService != null && !udpSenderService.isRunning())
             stopService(new Intent(this, UdpSenderService.class));
         save();


### PR DESCRIPTION
With the changes and debug option disabled, there's none or almost none memory allocation as per Android Studio profiler. Debug allocation can't be helped since it updates text in the UI.

There's also CPU usage reduction. It was stupid high before, now it's 20%

Check at least if it works on a phone with a gyro!!! Mine has none and can't confirm for sure I got float byte order right.