### PR TITLE
Added joystick.name accessor

### DIFF
--- a/FreePIE.Core.Plugins/JoystickPlugin.cs
+++ b/FreePIE.Core.Plugins/JoystickPlugin.cs
@@ -77,7 +77,7 @@ namespace FreePIE.Core.Plugins
 
         public void SetRange(int lowerRange, int upperRange)
         {
-            foreach (DeviceObjectInstance deviceObject in joystick.GetObjects()) 
+            foreach (DeviceObjectInstance deviceObject in joystick.GetObjects())
             {
                 if ((deviceObject.ObjectType & ObjectDeviceType.Axis) != 0)
                     joystick.GetObjectPropertiesById((int)deviceObject.ObjectType).SetRange(lowerRange, upperRange);
@@ -92,6 +92,11 @@ namespace FreePIE.Core.Plugins
         public bool GetDown(int button)
         {
             return State.IsPressed(button);
+        }
+
+        internal Joystick Joystick
+        {
+            get { return joystick; }
         }
     }
 
@@ -134,7 +139,7 @@ namespace FreePIE.Core.Plugins
 
         public int z
         {
-            get { return State.Z;  }
+            get { return State.Z; }
         }
 
         public int xRotation
@@ -160,6 +165,11 @@ namespace FreePIE.Core.Plugins
         public int[] pov
         {
             get { return State.GetPointOfViewControllers(); }
+        }
+
+        public string name
+        {
+            get { return device.Joystick.Information.InstanceName; }
         }
     }
 }


### PR DESCRIPTION
I've exposed joystick.name field to python. This allows scripts to manage devices by name.

Using the following python functions, you can store an accessor to a joystick device retrieved by its name (as seen in joy.cpl), so controller scripts can be made agnostic to device indices (which can easily change when devices are un/plugged).

```
def get_joystick_index(name, joysticks):
	i = 0
	for j in joysticks:
		if (j.name == name):
			return i
		i = i + 1
	return -1
	
def get_joystick_accessor(name, joysticks):
	index = get_joystick_index(name, joysticks)
	if (not(index == -1)):
		return lambda: joysticks[index] 
	else:
		return null
```

Finally, on the user script side, joystick accessors are used like this:

```
import harvutil

if (starting):
	global getSidePanel
	getSidePanel = harvutil.get_joystick_accessor("Saitek Side Panel Control Deck", joystick)
	
	global getPedals
	getPedals = harvutil.get_joystick_accessor("Saitek Pro Flight Rudder Pedals", joystick)

#steering
	vJoy[0].y = getPedals().zRotation * 16.4 + \
				(getSidePanel().xRotation * 16.4 * (1 + (0.7 * abs(getSidePanel().yRotation) / 1000))) 

	#accel/brakes
	vJoy[0].x = (getSidePanel().yRotation * 16.4 * (1 + (0.7 * abs(getSidePanel().xRotation) / 1000))) + \
				filters.mapRange(getPedals().y, -1000, 1000, 0, -16354) + \
				filters.mapRange(getPedals().x, -1000, 1000, 0, 16354)

```
_in this example, the functions above are defined in a harvutil.py module_

This is only made possible with this change to JoystickPlugin.cs, which exposes the instance name of joystick devices to python. Hopefully this change can be merged in without any problems, but feel free to tweak as needed for proper code style/consistency/sanity.

Cheers