### PR TITLE
Fixed Wiimote calibration for multiple wiimotes

### DIFF
--- a/FreePIE.Core.Plugins/Wiimote/DolphiimoteBridge.cs
+++ b/FreePIE.Core.Plugins/Wiimote/DolphiimoteBridge.cs
@@ -33,10 +33,7 @@ namespace FreePIE.Core.Plugins.Wiimote
             data = new Dictionary<uint, DolphiimoteWiimoteData>();
 
             for (byte i = 0; i < 4; i++)
-            {
-                calibration = new WiimoteCalibration();
-                data[i] = new DolphiimoteWiimoteData(i, calibration, fuserFactory());
-            }
+                data[i] = new DolphiimoteWiimoteData(i, new WiimoteCalibration(), fuserFactory());
         }
 
         public void Init()

--- a/FreePIE.Core.Plugins/Wiimote/DolphiimoteBridge.cs
+++ b/FreePIE.Core.Plugins/Wiimote/DolphiimoteBridge.cs
@@ -25,7 +25,6 @@ namespace FreePIE.Core.Plugins.Wiimote
             this.logFile = logFile;
             this.fuserFactory = fuserFactory;
 
-            calibration = new WiimoteCalibration();
             dll = new DolphiimoteDll(Path.Combine(Environment.CurrentDirectory, "DolphiiMote.dll"));
 
             deferredEnables = new Queue<KeyValuePair<byte, WiimoteCapabilities>>();
@@ -34,7 +33,10 @@ namespace FreePIE.Core.Plugins.Wiimote
             data = new Dictionary<uint, DolphiimoteWiimoteData>();
 
             for (byte i = 0; i < 4; i++)
+            {
+                calibration = new WiimoteCalibration();
                 data[i] = new DolphiimoteWiimoteData(i, calibration, fuserFactory());
+            }
         }
 
         public void Init()


### PR DESCRIPTION
The WiimoteCalibration object should have been created anew for each Wiimote.
