### PR TITLE
Index on joystick name fix for duplicate joysticks of the same name

### DIFF
--- a/FreePIE.Core.Plugins/Globals/GlobalIndexer.cs
+++ b/FreePIE.Core.Plugins/Globals/GlobalIndexer.cs
@@ -37,16 +37,40 @@ namespace FreePIE.Core.Plugins.Globals
 
     public class GlobalIndexer<T, TIndexOne, TIndexTwo> : GlobalIndexer<T, TIndexOne>
     {
-        private readonly GlobalIndexer<T, TIndexTwo> indexerTwo; 
+        private readonly Func<TIndexTwo, int, T> _initializerTwo;
+        private readonly Dictionary<TIndexTwo, Dictionary<int, T>> globals2;
 
-        public GlobalIndexer(Func<TIndexOne, T> initilizerOne, Func<TIndexTwo, T> initilizerTwo) : base(initilizerOne)
+        public GlobalIndexer(
+            Func<TIndexOne, T> initializerOne,
+            Func<TIndexTwo, int, T> initializerTwo
+            ) : base(initializerOne)
         {
-            this.indexerTwo = new GlobalIndexer<T, TIndexTwo>(initilizerTwo);
+            _initializerTwo = initializerTwo;
+            globals2 = new Dictionary<TIndexTwo, Dictionary<int, T>>();
         }
 
-        public T this[TIndexTwo index]
+
+        public T this[TIndexTwo key, int index = 0]
         {
-            get { return indexerTwo[index]; }
+            get
+            {
+                Dictionary<int, T> theKey;
+                T theglobal;
+                if (!globals2.TryGetValue(key, out theKey))
+                {
+                    globals2[key] = theKey = new Dictionary<int, T>();
+                }
+
+
+                if (!theKey.TryGetValue(index, out theglobal))
+                {
+                    theKey[index] = theglobal = _initializerTwo(key, index);
+                }
+
+
+                return theglobal;
+            }
         }
     }
+    
 }

--- a/FreePIE.Core.Plugins/JoystickPlugin.cs
+++ b/FreePIE.Core.Plugins/JoystickPlugin.cs
@@ -32,7 +32,12 @@ namespace FreePIE.Core.Plugins
                 return new JoystickGlobal(device);
             });
             
-            return new GlobalIndexer<JoystickGlobal, int, string>(index => creator(diDevices[index]), index => creator(diDevices.Single(di => di.InstanceName == index)));
+            return new GlobalIndexer<JoystickGlobal, int, string>(intIndex => creator(diDevices[intIndex]),(strIndex, idx) =>
+            {
+                    var d = diDevices.Where(di => di.InstanceName == strIndex).ToArray();
+                    return d.Length > 0 && d.Length > idx ? creator(d[idx]) : null;
+            }
+            );
         }
 
         public override void Stop()

--- a/FreePIE.Core.Plugins/JoystickPlugin.cs
+++ b/FreePIE.Core.Plugins/JoystickPlugin.cs
@@ -36,8 +36,7 @@ namespace FreePIE.Core.Plugins
             {
                     var d = diDevices.Where(di => di.InstanceName == strIndex).ToArray();
                     return d.Length > 0 && d.Length > idx ? creator(d[idx]) : null;
-            }
-            );
+            });
         }
 
         public override void Stop()


### PR DESCRIPTION
Existing approach to indexing joysticks by name assumes that all joysticks plugged in have different names. And will throw an error when trying to reference. because it returns more than one device.

This update allows indexing by name and index to specify both joysticks with the same name

example watch the pov's of dual thrustmaster T16000M joysticks
`diagnostics.watch(joystick["T.16000M",0].pov[0])`
`diagnostics.watch(joystick["T.16000M",1].pov[0])`

or specify the first device found same syntax as before _(the index is optional and defaults to 0)_
`diagnostics.watch(joystick["T.16000M"].pov[0])`
