### PR TITLE
Added tray icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ VersionInfo.cs
 Output
 OutputTemp
 InstallerTemp
+/Lib/OculusVR/Code/OculusSDK.7z
+/Lib/HEAD.zip

--- a/FreePIE.Core/FreePIE.Core.csproj
+++ b/FreePIE.Core/FreePIE.Core.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Model\Choices.cs" />
     <Compile Include="Model\Events\CurveChangedNameEvent.cs" />
     <Compile Include="Model\Events\ScriptErrorEvent.cs" />
+    <Compile Include="Model\Events\TrayNotificationEvent.cs" />
     <Compile Include="Model\Events\WatchEvent.cs" />
     <Compile Include="Model\PluginProperty.cs" />
     <Compile Include="Model\PluginSetting.cs" />

--- a/FreePIE.Core/Model/Events/TrayNotificationEvent.cs
+++ b/FreePIE.Core/Model/Events/TrayNotificationEvent.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FreePIE.Core.Model.Events
+{
+    public class TrayNotificationEvent 
+    {
+        public DateTime EventTime = DateTime.Now;
+
+        //public BalloonIcon Icon { get; set; }
+
+        public string Title { get; set; }
+        public string message { get; set; }
+
+        public TrayNotificationEvent()
+        {
+
+        }
+
+        public TrayNotificationEvent(string message, string title = "")//, BalloonIcon icon = BalloonIcon.Info)
+        {
+            this.message = message;
+            this.Title = title;
+            //this.Icon = icon;
+        }
+
+        public override string ToString()
+        {
+            return message;
+        }
+    }
+}

--- a/FreePIE.Core/Model/Settings.cs
+++ b/FreePIE.Core/Model/Settings.cs
@@ -7,6 +7,7 @@ namespace FreePIE.Core.Model
     {
         public List<Curve> Curves { get; set; }
         public List<PluginSetting> PluginSettings { get; set; }
+        public bool MinimizeToTray { get; set; }
 
         public Settings()
         {

--- a/FreePIE.Core/ScriptEngine/Globals/ScriptHelpers/DiagnosticHelper.cs
+++ b/FreePIE.Core/ScriptEngine/Globals/ScriptHelpers/DiagnosticHelper.cs
@@ -30,5 +30,23 @@ namespace FreePIE.Core.ScriptEngine.Globals.ScriptHelpers
         {
             eventAggregator.Publish(new WatchEvent(indexer, value));
         }
+
+        public void notify(string message)
+        {
+            eventAggregator.Publish(new TrayNotificationEvent(message, ""));
+
+        }
+        public void notify(string title, string message)
+        {
+            eventAggregator.Publish(new TrayNotificationEvent(message, title));
+
+        }
+        public void notify(string title,string message, params object[] args)
+        {
+            eventAggregator.Publish(new TrayNotificationEvent(string.Format(message, args),title));
+           
+        }
+
+        
     }
 }

--- a/FreePIE.GUI/Bootstrap/BootStrapper.cs
+++ b/FreePIE.GUI/Bootstrap/BootStrapper.cs
@@ -6,6 +6,7 @@ using FreePIE.Core.Persistence;
 using FreePIE.Core.Services;
 using FreePIE.GUI.Common.AvalonDock;
 using FreePIE.GUI.Common.CommandLine;
+using FreePIE.GUI.Common.TrayIcon;
 using FreePIE.GUI.Result;
 using FreePIE.GUI.Shells;
 using FreePIE.GUI.Views.Main;
@@ -32,8 +33,8 @@ namespace FreePIE.GUI.Bootstrap
             kernel.Bind<IWindowManager>().To<WindowManager>().InSingletonScope();
             kernel.Bind<IResultFactory>().To<ResultFactory>();
             kernel.Bind<IParser>().To<Parser>();
-
-			ConfigurePanels();
+            kernel.Bind<ITrayIcon>().To<TrayIconViewModel>().InSingletonScope();
+            ConfigurePanels();
 
             SetupCustomMessageBindings();
         }
@@ -49,7 +50,8 @@ namespace FreePIE.GUI.Bootstrap
 	    {
 	        Coroutine.BeginExecute(kernel
                 .Get<SettingsLoaderViewModel>()
-                .Load(() => DisplayRootViewFor<MainShellViewModel>())
+                //.Load(() => DisplayRootViewFor<MainShellViewModel>())
+                .Load(() => DisplayRootViewFor<ITrayIcon>())
                 .GetEnumerator());
         }
 

--- a/FreePIE.GUI/Bootstrap/BootStrapper.cs
+++ b/FreePIE.GUI/Bootstrap/BootStrapper.cs
@@ -2,11 +2,9 @@
 using System.Collections.Generic;
 using System.Windows;
 using Caliburn.Micro;
-using FreePIE.Core.Persistence;
 using FreePIE.Core.Services;
 using FreePIE.GUI.Common.AvalonDock;
 using FreePIE.GUI.Common.CommandLine;
-using FreePIE.GUI.Common.TrayIcon;
 using FreePIE.GUI.Result;
 using FreePIE.GUI.Shells;
 using FreePIE.GUI.Views.Main;
@@ -33,7 +31,8 @@ namespace FreePIE.GUI.Bootstrap
             kernel.Bind<IWindowManager>().To<WindowManager>().InSingletonScope();
             kernel.Bind<IResultFactory>().To<ResultFactory>();
             kernel.Bind<IParser>().To<Parser>();
-            kernel.Bind<ITrayIcon>().To<TrayIconViewModel>().InSingletonScope();
+            kernel.Bind<MainShellViewModel>().ToSelf().InSingletonScope();
+            kernel.Bind<TrayIconViewModel>().ToSelf().InSingletonScope();
             ConfigurePanels();
 
             SetupCustomMessageBindings();
@@ -50,9 +49,14 @@ namespace FreePIE.GUI.Bootstrap
 	    {
 	        Coroutine.BeginExecute(kernel
                 .Get<SettingsLoaderViewModel>()
-                //.Load(() => DisplayRootViewFor<MainShellViewModel>())
-                .Load(() => DisplayRootViewFor<ITrayIcon>())
+                .Load(OnSettingsLoaded)
                 .GetEnumerator());
+        }
+
+        private void OnSettingsLoaded()
+        {
+            DisplayRootViewFor<TrayIconViewModel>();
+            DisplayRootViewFor<MainShellViewModel>();
         }
 
         protected override object GetInstance(Type service, string key)

--- a/FreePIE.GUI/Common/CommandLine/Commands/TrayCommand.cs
+++ b/FreePIE.GUI/Common/CommandLine/Commands/TrayCommand.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using FreePIE.Core.Common.Events;
+using FreePIE.GUI.Events.Command;
+
+namespace FreePIE.GUI.Common.CommandLine.Commands
+{
+    public class TrayCommand : Command<TrayEvent>
+    {
+        public TrayCommand(IEventAggregator eventAggregator) : base(eventAggregator)
+        {
+        }
+
+        public override IEnumerable<string> Keys
+        {
+            get { return new[] { "t", "tray" }; }
+        }
+    }
+}

--- a/FreePIE.GUI/Common/TrayIcon/ITrayIcon.cs
+++ b/FreePIE.GUI/Common/TrayIcon/ITrayIcon.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls.Primitives;
+using Hardcodet.Wpf.TaskbarNotification;
+
+namespace FreePIE.GUI.Common.TrayIcon
+{
+    public interface ITrayIcon : IDisposable
+    {
+        TaskbarIcon TaskbarTrayIcon { get; }
+        void ShowWindow();
+        void HideWindow();
+        void ExitApplication();
+
+
+        void ShowBalloonTip(string title, string message, BalloonIcon balloon);
+
+        void ShowBalloonTip(UIElement rootModel, PopupAnimation animation, int timeout = 4000);
+
+        void CloseBalloon();
+
+        void OnTrayIconLoaded(object source);
+    }
+}

--- a/FreePIE.GUI/Events/Command/TrayEvent.cs
+++ b/FreePIE.GUI/Events/Command/TrayEvent.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Hardcodet.Wpf.TaskbarNotification;
+
+namespace FreePIE.GUI.Events.Command
+{
+    public class TrayEvent : CommandEvent
+    {
+
+    }
+    
+}

--- a/FreePIE.GUI/Events/ScriptStateChangedEvent.cs
+++ b/FreePIE.GUI/Events/ScriptStateChangedEvent.cs
@@ -3,9 +3,12 @@
     public class ScriptStateChangedEvent
     {
         public bool Running { get; set; }
-        public ScriptStateChangedEvent(bool running)
+
+        public string Script { get; set; }
+        public ScriptStateChangedEvent(bool running, string script)
         {
             Running = running;
+            Script = script;
         }
     }
 }

--- a/FreePIE.GUI/FreePIE.GUI.csproj
+++ b/FreePIE.GUI/FreePIE.GUI.csproj
@@ -67,6 +67,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Caliburn.Micro.2.0.1\lib\net40\Caliburn.Micro.Platform.dll</HintPath>
     </Reference>
+    <Reference Include="Hardcodet.Wpf.TaskbarNotification, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Hardcodet.NotifyIcon.Wpf.1.0.8\lib\net45\Hardcodet.Wpf.TaskbarNotification.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="ICSharpCode.AvalonEdit, Version=5.0.1.0, Culture=neutral, PublicKeyToken=9cc39be672370310, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\AvalonEdit.5.0.2\lib\Net40\ICSharpCode.AvalonEdit.dll</HintPath>
@@ -76,6 +80,7 @@
       <HintPath>..\packages\Ninject.3.2.2.0\lib\net40\Ninject.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Interactivity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Caliburn.Micro.2.0.1\lib\net40\System.Windows.Interactivity.dll</HintPath>
     </Reference>
@@ -115,6 +120,7 @@
     <Compile Include="Common\CommandLine\Commands\Command.cs" />
     <Compile Include="Common\CommandLine\Commands\FileCommand.cs" />
     <Compile Include="Common\CommandLine\Commands\RunCommand.cs" />
+    <Compile Include="Common\CommandLine\Commands\TrayCommand.cs" />
     <Compile Include="Common\CommandLine\IParser.cs" />
     <Compile Include="Common\CommandLine\Parser.cs" />
     <Compile Include="Common\Resources\ResourceHelper.cs" />
@@ -125,6 +131,7 @@
     <Compile Include="Events\Command\CommandEvent.cs" />
     <Compile Include="Events\Command\FileEvent.cs" />
     <Compile Include="Events\Command\RunEvent.cs" />
+    <Compile Include="Events\Command\TrayEvent.cs" />
     <Compile Include="Events\DeleteCurveEvent.cs" />
     <Compile Include="Events\ScriptDocumentAddedEvent.cs" />
     <Compile Include="Events\ExitingEvent.cs" />
@@ -168,12 +175,17 @@
       <DependentUpon>CurveView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\Curves\CurveViewModel.cs" />
+    <Compile Include="Common\TrayIcon\ITrayIcon.cs" />
     <Compile Include="Views\Main\MainMenuView.xaml.cs">
       <DependentUpon>MainMenuView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\Main\MainMenuViewModel.cs" />
     <Compile Include="Views\Main\PanelViewModel.cs" />
     <Compile Include="Views\Main\SettingsLoaderViewModel.cs" />
+    <Compile Include="Views\Main\TrayIconView.xaml.cs">
+      <DependentUpon>TrayIconView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\Main\TrayIconViewModel.cs" />
     <Compile Include="Views\Plugin\PluginHelpFileViewModel.cs" />
     <Compile Include="Views\Plugin\PluginPropertyView.xaml.cs">
       <DependentUpon>PluginPropertyView.xaml</DependentUpon>
@@ -253,6 +265,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\Main\MainMenuView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\Main\TrayIconView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -409,6 +425,7 @@
   <ItemGroup>
     <Resource Include="Resources\prev-16.png" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>md "$(TargetDir)plugins"

--- a/FreePIE.GUI/Shells/MainShellView.xaml
+++ b/FreePIE.GUI/Shells/MainShellView.xaml
@@ -4,7 +4,9 @@
         xmlns:i="clr-namespace:System.Windows.Interactivity;assembly=System.Windows.Interactivity"
         xmlns:xcad="http://schemas.xceed.com/wpf/xaml/avalondock"
         xmlns:avalonDock1="clr-namespace:FreePIE.GUI.Common.AvalonDock"
-        Title="FreePIE" Background="{DynamicResource WindowBackgroundBrush}">
+        Title="FreePIE" Background="{DynamicResource WindowBackgroundBrush}" 
+        WindowState="{Binding WindowState, Mode = TwoWay}" 
+        ShowInTaskbar="{Binding ShowInTaskBar, Mode=TwoWay}">
     <Window.Resources>
         <xcad:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
     </Window.Resources>

--- a/FreePIE.GUI/Shells/MainShellViewModel.cs
+++ b/FreePIE.GUI/Shells/MainShellViewModel.cs
@@ -6,7 +6,6 @@ using FreePIE.Core.Common;
 using FreePIE.Core.Persistence;
 using FreePIE.Core.Persistence.Paths;
 using FreePIE.GUI.Common.AvalonDock;
-using FreePIE.GUI.Common.CommandLine;
 using FreePIE.GUI.Common.Strategies;
 using FreePIE.GUI.Events;
 using FreePIE.GUI.Result;
@@ -31,8 +30,7 @@ namespace FreePIE.GUI.Shells
         private readonly IFileSystem fileSystem;
         private readonly ScriptDialogStrategy scriptDialogStrategy;
         private readonly IPaths paths;
-        private readonly IParser parser;
-
+        private bool loaded;
         public MainShellViewModel(IResultFactory resultFactory,
                                   IEventAggregator eventAggregator,
                                   IPersistanceManager persistanceManager,
@@ -42,7 +40,6 @@ namespace FreePIE.GUI.Shells
                                   IFileSystem fileSystem,
                                   ScriptDialogStrategy scriptDialogStrategy,
                                   IPaths paths,
-                                  IParser parser,
                                   IPortable portable
             )
             : base(resultFactory)
@@ -53,7 +50,6 @@ namespace FreePIE.GUI.Shells
             this.fileSystem = fileSystem;
             this.scriptDialogStrategy = scriptDialogStrategy;
             this.paths = paths;
-            this.parser = parser;
 
             Scripts = new BindableCollection<ScriptEditorViewModel>();
             Tools = new BindableCollection<PanelViewModel> (panels);
@@ -68,13 +64,17 @@ namespace FreePIE.GUI.Shells
             DisplayName = string.Format("FreePIE - Programmable Input Emulator{0}", portable.IsPortable ? " (Portable mode)" : null);
         }
 
+        
         protected override void OnViewLoaded(object view)
         {
             base.OnViewLoaded(view);
-            InitDocking();
+            if (!loaded)
+            {
+                loaded = true;
+                InitDocking();
 
-            eventAggregator.Publish(new StartedEvent());
-            parser.ParseAndExecute();
+                eventAggregator.Publish(new StartedEvent());
+            }
         }
 
         private void InitDocking()
@@ -174,6 +174,9 @@ namespace FreePIE.GUI.Shells
             }
 
             script.IsActive = true;
+
+            
+            ActiveDocument = message.Document;
         }
     }
 }

--- a/FreePIE.GUI/Views/Main/MainMenuViewModel.cs
+++ b/FreePIE.GUI/Views/Main/MainMenuViewModel.cs
@@ -160,7 +160,7 @@ namespace FreePIE.GUI.Views.Main
         {
             NotifyOfPropertyChange(() => CanRunScript);
             NotifyOfPropertyChange(() => CanStopScript);
-            eventAggregator.Publish(new ScriptStateChangedEvent(scriptRunning));
+            eventAggregator.Publish(new ScriptStateChangedEvent(scriptRunning, activeDocument.Filename));
         }
 
         public bool CanStopScript
@@ -211,10 +211,6 @@ namespace FreePIE.GUI.Views.Main
 
         public IEnumerable<IResult> Close()
         {
-            //this closes to tray
-            //yield return resultFactory.Close();
-
-            //this actually exits the app
             yield return resultFactory.CloseApp();
         }
 

--- a/FreePIE.GUI/Views/Main/MainMenuViewModel.cs
+++ b/FreePIE.GUI/Views/Main/MainMenuViewModel.cs
@@ -81,8 +81,10 @@ namespace FreePIE.GUI.Views.Main
 
             if (!string.IsNullOrEmpty(filePath))
                 document.LoadFileContent(fileSystem.ReadAllText(filePath));
-
+            
             eventAggregator.Publish(new ScriptDocumentAddedEvent(document));
+            
+            //ActiveDocument = document;
         }
 
         public IEnumerable<IResult> SaveScript()
@@ -209,7 +211,11 @@ namespace FreePIE.GUI.Views.Main
 
         public IEnumerable<IResult> Close()
         {
-            yield return resultFactory.Close();
+            //this closes to tray
+            //yield return resultFactory.Close();
+
+            //this actually exits the app
+            yield return resultFactory.CloseApp();
         }
 
         public IEnumerable<IResult> ShowCurveSettingsMenu()

--- a/FreePIE.GUI/Views/Main/TrayIconView.xaml
+++ b/FreePIE.GUI/Views/Main/TrayIconView.xaml
@@ -12,21 +12,31 @@
         WindowStyle="None"
         AllowsTransparency="True"
         Background="Transparent"
-        Visibility="Hidden">
+        Visibility="Hidden" ShowInTaskbar="False">
     <Window.Resources>
 
         <ResourceDictionary>
             <ContextMenu x:Shared="false" x:Key="MainSysTrayMenu">
-               <MenuItem Header="Show Window" cal:Message.Attach="ShowWindow" />
-                <MenuItem Header="Hide Window" cal:Message.Attach="HideWindow" />
+
+                <MenuItem Header="Run Script" cal:Message.Attach="RunScript" />
+                <MenuItem Header="Stop Script" cal:Message.Attach="StopScript" />
                 <Separator />
-                <MenuItem Header="Exit" cal:Message.Attach="ExitApplication" />
+                <MenuItem Header="Show Window" cal:Message.Attach="ShowWindow" />
+                <MenuItem>
+                    <MenuItem.Header>
+                        <CheckBox Content="Minimize to Tray" IsChecked="{Binding Path=MinimizeToTray,Mode=TwoWay}"></CheckBox>
+                    </MenuItem.Header>
+
+                </MenuItem>
+                <MenuItem Header="Exit Freepie" cal:Message.Attach="Close" />
+
             </ContextMenu>
 
             <!-- the application main system tray icon -->
             <tb:TaskbarIcon x:Key="MyTrayIcon"
                         IconSource="/free-pie.ico"
-                        ToolTipText="Double-click for window, right-click for menu"
+                        ToolTipText="{Binding Path=ToolTipText}"
+                            
                         cal:Message.Attach="[Event TrayMouseDoubleClick] = [Action ShowWindow]"
                         ContextMenu="{StaticResource MainSysTrayMenu}"  />
         </ResourceDictionary>
@@ -34,6 +44,6 @@
 
     <Grid>
         <TextBlock >View + ViewModel started from bootstrapper. This should not be visible.</TextBlock>
-        <ContentControl Content="{StaticResource MyTrayIcon}" cal:Message.Attach="[Event Loaded] = [Action OnTrayIconLoaded($source)]"/>
+        <ContentControl x:Name="TrayiconControl" Content="{StaticResource MyTrayIcon}" cal:Message.Attach="[Event Loaded] = [Action OnTrayIconLoaded($source)]" />
     </Grid>
 </Window>

--- a/FreePIE.GUI/Views/Main/TrayIconView.xaml
+++ b/FreePIE.GUI/Views/Main/TrayIconView.xaml
@@ -1,0 +1,39 @@
+﻿<Window x:Class="FreePIE.GUI.Views.Main.TrayIconView"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:FreePIE.GUI.Views.Main"
+        xmlns:cal="http://www.caliburnproject.org"
+        xmlns:tb="http://www.hardcodet.net/taskbar"
+        mc:Ignorable="d"
+        Title="TrayIconView" Height="0" Width="0"
+        WindowStartupLocation="CenterScreen"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        Visibility="Hidden">
+    <Window.Resources>
+
+        <ResourceDictionary>
+            <ContextMenu x:Shared="false" x:Key="MainSysTrayMenu">
+               <MenuItem Header="Show Window" cal:Message.Attach="ShowWindow" />
+                <MenuItem Header="Hide Window" cal:Message.Attach="HideWindow" />
+                <Separator />
+                <MenuItem Header="Exit" cal:Message.Attach="ExitApplication" />
+            </ContextMenu>
+
+            <!-- the application main system tray icon -->
+            <tb:TaskbarIcon x:Key="MyTrayIcon"
+                        IconSource="/free-pie.ico"
+                        ToolTipText="Double-click for window, right-click for menu"
+                        cal:Message.Attach="[Event TrayMouseDoubleClick] = [Action ShowWindow]"
+                        ContextMenu="{StaticResource MainSysTrayMenu}"  />
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <Grid>
+        <TextBlock >View + ViewModel started from bootstrapper. This should not be visible.</TextBlock>
+        <ContentControl Content="{StaticResource MyTrayIcon}" cal:Message.Attach="[Event Loaded] = [Action OnTrayIconLoaded($source)]"/>
+    </Grid>
+</Window>

--- a/FreePIE.GUI/Views/Main/TrayIconView.xaml.cs
+++ b/FreePIE.GUI/Views/Main/TrayIconView.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace FreePIE.GUI.Views.Main
+{
+    /// <summary>
+    /// Interaction logic for TrayIconView.xaml
+    /// </summary>
+    public partial class TrayIconView : Window
+    {
+        public TrayIconView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/FreePIE.GUI/Views/Main/TrayIconView.xaml.cs
+++ b/FreePIE.GUI/Views/Main/TrayIconView.xaml.cs
@@ -23,5 +23,7 @@ namespace FreePIE.GUI.Views.Main
         {
             InitializeComponent();
         }
+
+        
     }
 }

--- a/FreePIE.GUI/Views/Main/TrayIconViewModel.cs
+++ b/FreePIE.GUI/Views/Main/TrayIconViewModel.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using Caliburn.Micro;
+using FreePIE.Core.Model.Events;
+using FreePIE.GUI.Common.CommandLine;
+using FreePIE.GUI.Common.TrayIcon;
+using FreePIE.GUI.Events.Command;
+using FreePIE.GUI.Result;
+using FreePIE.GUI.Shells;
+using Hardcodet.Wpf.TaskbarNotification;
+using IEventAggregator = FreePIE.Core.Common.Events.IEventAggregator;
+
+namespace FreePIE.GUI.Views.Main
+{
+    public class TrayIconViewModel : Screen, ITrayIcon, 
+        Core.Common.Events.IHandle<TrayNotificationEvent>, 
+        Core.Common.Events.IHandle<TrayEvent>
+    {
+        private readonly IEventAggregator eventAggregator;
+        private readonly IResultFactory resultFactory;
+        private readonly IWindowManager windowManager;
+        private readonly MainShellViewModel shellViewModel;
+        private readonly IParser parser;
+
+        public TrayIconViewModel(IResultFactory resultFactory, IEventAggregator eventAggregator, IWindowManager windowManager,
+            MainShellViewModel shellViewModel,
+            IParser parser)
+        {
+            this.resultFactory = resultFactory;
+            this.windowManager = windowManager;
+            this.parser = parser;
+            this.shellViewModel = shellViewModel;
+
+            this.eventAggregator = eventAggregator;
+            this.eventAggregator.Subscribe(this);
+        }
+
+        #region ITrayIcon Implementation
+
+        protected override void OnActivate()
+        {
+            base.OnActivate();
+
+            NotifyOfPropertyChange(() => CanShowWindow);
+            NotifyOfPropertyChange(() => CanHideWindow);
+        }
+
+        public bool CanShowWindow => (!shellViewModel.IsActive);
+
+        /// <summary>
+        /// If true application starts minimized in the taskbar
+        /// </summary>
+        private bool StartInTray { get; set; }
+        public void OnTrayIconLoaded(object source)
+        {
+            TaskbarTrayIcon = ((ContentControl)source).Content as TaskbarIcon;
+            
+            parser.ParseAndExecute();
+
+            if (CanShowWindow && !StartInTray)
+                ShowWindow();
+            //int i = Array.IndexOf(w.startupArgs, "/open");
+
+
+        }
+
+        public void ShowWindow()
+        {
+            windowManager.ShowWindow(shellViewModel);
+
+            NotifyOfPropertyChange(() => CanShowWindow);
+            NotifyOfPropertyChange(() => CanHideWindow);
+        }
+
+        public bool CanHideWindow
+        {
+            get
+            {
+                return (shellViewModel.IsActive);
+            }
+        }
+
+        public void HideWindow()
+        {
+            shellViewModel.TryClose();
+
+            NotifyOfPropertyChange(() => CanShowWindow);
+            NotifyOfPropertyChange(() => CanHideWindow);
+        }
+
+        public void ExitApplication()
+        {
+             resultFactory.CloseApp().Execute(null);
+        }
+
+        public IEnumerable<IResult> Close()
+        {
+            yield return resultFactory.CloseApp();
+        }
+
+        #region TrayIcon
+
+        public TaskbarIcon TaskbarTrayIcon
+        {
+            get;
+            private set;
+        }
+
+
+        public void ShowBalloonTip(string title, string message)
+        {
+            ShowBalloonTip(title, message, BalloonIcon.Info);
+        }
+        public void ShowBalloonTip(string title, string message, BalloonIcon balloon)
+        {
+            //Icon.ShowBalloonTip(title, message, balloon);
+            TaskbarTrayIcon?.ShowBalloonTip(title, message, balloon);
+        }
+
+        public void ShowBalloonTip(UIElement rootModel, PopupAnimation animation, int timeout = 4000)
+        {
+            TaskbarTrayIcon?.ShowCustomBalloon(rootModel, animation, timeout);
+        }
+
+
+        /*public void ShowBalloonTip(object rootModel, PopupAnimation animation, TimeSpan? timeout = null)
+        {
+            Icon.ShowBalloonTip(rootModel, animation, timeout);
+        }*/
+
+        public void CloseBalloon()
+        {
+            TaskbarTrayIcon?.CloseBalloon();
+        }
+        #endregion
+
+        public void Dispose()
+        {
+            TaskbarTrayIcon?.Dispose();
+        }
+
+        /// <summary>
+        /// Show a balloon notification in the taskbar
+        /// </summary>
+        /// <param name="message"></param>
+        public void Handle(TrayNotificationEvent message)
+        {
+            TaskbarTrayIcon?.ShowBalloonTip(message.Title, message.message, BalloonIcon.Info);
+        }
+
+        public void Handle(TrayEvent message)
+        {
+            //prevent main window from showing automatically
+            StartInTray = true;
+        }
+
+        #endregion
+    }
+}

--- a/FreePIE.GUI/packages.config
+++ b/FreePIE.GUI/packages.config
@@ -3,5 +3,6 @@
   <package id="AvalonEdit" version="5.0.2" targetFramework="net45" />
   <package id="Caliburn.Micro" version="2.0.1" targetFramework="net45" />
   <package id="Caliburn.Micro.Core" version="2.0.1" targetFramework="net45" />
+  <package id="Hardcodet.NotifyIcon.Wpf" version="1.0.8" targetFramework="net45" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net45-full" />
 </packages>


### PR DESCRIPTION
regarding issue #98
added new function diagnostics.notify(string title, string message, format args) so you can pop up notifications in the taskbar via python script!

added command line option /t or /tray to start minimized
example usage 
`freepie.exe /tray "myscript.py" /run`  
will autorun the script in the tray

diagnostics.notify example usage:
`if starting:  diagnostics.notify("Starting Script ...")`

