### PR TITLE
Add Equals and GetHashCode for Point class

### DIFF
--- a/FreePIE.Core/Model/Curve.cs
+++ b/FreePIE.Core/Model/Curve.cs
@@ -65,5 +65,24 @@ namespace FreePIE.Core.Model
         {
             return !(x == y);
         }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            return obj is Point && Equals((Point) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (X.GetHashCode() * 397) ^ Y.GetHashCode();
+            }
+        }
+
+        public bool Equals(Point other)
+        {
+            return X.Equals(other.X) && Y.Equals(other.Y);
+        }
     }
 }


### PR DESCRIPTION
The contract for == and != requires that Equals and GetHashCode have
been defined. Used Resharper to add these functions for the point class.

	modified:   Curve.cs