### PR TITLE
Fix for #126 - "cannot access dolphiimote.log"

### DIFF
--- a/BuildTools/build_installer.bat
+++ b/BuildTools/build_installer.bat
@@ -6,3 +6,4 @@ cd %~dp0
 msbuild write_VersionInfo.xml
 msbuild build_output.xml /property:OutputTemp=..\OutputTemp /property:BuildDir=..\Output /property:Lib=..\Lib /property:Help=..\FreePIE.Core.Plugins\Help
 msbuild build_installer.xml /property:InstallerTemp=..\InstallerTemp /property:Lib=..\Lib
+pause

--- a/FreePIE.Core.Plugins/Wiimote/DolphiimoteBridge.cs
+++ b/FreePIE.Core.Plugins/Wiimote/DolphiimoteBridge.cs
@@ -56,7 +56,17 @@ namespace FreePIE.Core.Plugins.Wiimote
         {
             if(logFile == null)
                 Debug.WriteLine(log);
-            else File.AppendAllText(logFile, log);
+            else
+                try
+                {
+                    File.AppendAllText(logFile, log);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                    Debug.WriteLine(log);
+                    //throw;
+                }
         }
 
         private Exception occuredException;

--- a/FreePIE.Core.Plugins/WiimotePlugin.cs
+++ b/FreePIE.Core.Plugins/WiimotePlugin.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using FreePIE.Core.Contracts;
 using FreePIE.Core.Plugins.Wiimote;
+using System.IO;
 using System.Linq;
 
 namespace FreePIE.Core.Plugins
@@ -115,7 +116,11 @@ namespace FreePIE.Core.Plugins
 
         public override object CreateGlobal()
         {
-            wiimoteBridge = new DolphiimoteBridge(logLevel, doLog ? "dolphiimote.log" : null, CreateMotionplusFuser);
+            string applicationDataSubPath = @"FreePIE\dolphiimote.log";
+            var applicationDataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), applicationDataSubPath);
+            var dolphiimoteLogPath = !Environment.CurrentDirectory.StartsWith(@"C:\Program Files (x86)\FreePIE") 
+                ? @"dolphiimote.log" : applicationDataPath;
+            wiimoteBridge = new DolphiimoteBridge(logLevel, doLog ? dolphiimoteLogPath : null, CreateMotionplusFuser);
             globalUpdators = new Dictionary<uint, Action>();
             updatedWiimotes = new List<uint>();
             return Enumerable.Range(0, 4).Select(i => new WiimoteGlobal(this, wiimoteBridge.GetData((uint)i), globalUpdators)).ToArray();


### PR DESCRIPTION
The ApplicationData folder is now used if FreePIE is not in portable mode.
AppendAllText is now tried and the exception is logged if it fails.

A pause has also been added to the end of build_installer.bat so that the
messages can be read.