### PR TITLE
Numbered Recent Files List

### DIFF
--- a/FreePIE.GUI/Views/Main/MainMenuViewModel.cs
+++ b/FreePIE.GUI/Views/Main/MainMenuViewModel.cs
@@ -54,8 +54,13 @@ namespace FreePIE.GUI.Views.Main
             this.fileSystem = fileSystem;
             this.scriptDialogStrategy = scriptDialogStrategy;
             this.settingsManager = settings;
-
-            RecentScripts = new BindableCollection<string>(settingsManager.Settings.RecentScripts);
+            
+            var RecentScriptsTmp = new BindableCollection<string>(settingsManager.Settings.RecentScripts);
+            RecentScripts = new BindableCollection<string>();
+            for (int i = 0; i < RecentScriptsTmp.Count; i++)
+            {
+                RecentScripts.Add("_" + (i + 1).ToString() + " " + (!string.IsNullOrEmpty(RecentScriptsTmp.ElementAt(i)) ? RecentScriptsTmp.ElementAt(i) : ""));
+            }
         }
 
         private PanelViewModel activeDocument;
@@ -122,14 +127,18 @@ namespace FreePIE.GUI.Views.Main
 
         public void OpenRecentScript(string path)
         {
-            CreateScriptViewModel(path);
+            CreateScriptViewModel(path.Substring(3));
         }
 
         private void AddRecentScript(string filePath)
         {
             settingsManager.Settings.AddRecentScript(filePath);
             RecentScripts.Clear();
-            RecentScripts.AddRange(settingsManager.Settings.RecentScripts);
+            var RecentScriptsTmp = new BindableCollection<string>(settingsManager.Settings.RecentScripts);
+            for (int i = 0; i < RecentScriptsTmp.Count; i++)
+            {
+                RecentScripts.Add("_" + (i + 1).ToString() + " " + (!string.IsNullOrEmpty(RecentScriptsTmp.ElementAt(i)) ? RecentScriptsTmp.ElementAt(i) : ""));
+            }
         }
 
         public IEnumerable<IResult> QuickSaveScript()


### PR DESCRIPTION
The files can now be selected by pressing the associated number.

Previously if there were any underscores in the filenames, the character
after the first underscore was used as the mnemonic and the underscore was
hidden. Now all underscores are shown.

@AndersMalmgren Do you think there's a more efficient way to do this?

There's also a bug in saving an empty file which I haven't been able to fix. SaveAs is fine but it crashes if you then click Save without typing something first.

SaveAs also doesn't add the file to the recent files list but it does get added after pressing save (as long as the file isn't empty).