### PR TITLE
fix getActive for modern apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Build Folders (you can keep bin if you'd like, to store dlls and pdbs)
+.vs/
 bin
 obj
 *.suo


### PR DESCRIPTION
The `GetActiveWindowProcessName` always returns "ApplicationFrameHost" for UWP apps. If an UWP is detected in the foreground you need to get the name from the child process.