### PR TITLE
Added reset functionality to the SamplePeriodCounter. 

### DIFF
--- a/FreePIE.Core.Plugins/Wiimote/SamplePeriodCounter.cs
+++ b/FreePIE.Core.Plugins/Wiimote/SamplePeriodCounter.cs
@@ -26,6 +26,11 @@ namespace FreePIE.Core.Plugins.Wiimote
             {
                 stopwatch.Stop();
                 SamplePeriod = 1 / (float)(samples / stopwatch.Elapsed.TotalSeconds);
+
+                //Reset number of samples to zero and reset stopwatch after every update.
+                samples = 0;
+                stopwatch.Reset();
+
                 return true;
             }
 


### PR DESCRIPTION
By resetting samples to 0 every update cycle, SamplePeriodCounter.SamplePeriod should work better.

Testing done by me seem to indicate that the stationary drift (when the wiimote stays stationary) has decreased by this functionality.