### PR TITLE
Add method to disable speech plugin from python

### DIFF
--- a/FreePIE.Core.Plugins/SpeechPlugin.cs
+++ b/FreePIE.Core.Plugins/SpeechPlugin.cs
@@ -15,6 +15,7 @@ namespace FreePIE.Core.Plugins
         private SpeechRecognitionEngine recognitionEngine;
         private Dictionary<string, RecognitionInfo> recognizerResults;
 
+        private bool recognitionActive = true;
 
         public override object CreateGlobal()
         {
@@ -34,6 +35,11 @@ namespace FreePIE.Core.Plugins
             }
         }
 
+        public void EnableRecognition(bool enable)
+        {
+            recognitionActive = enable;   
+        }
+        
         public void SelectVoice(string name)
         {
             EnsureSynthesizer();
@@ -87,10 +93,14 @@ namespace FreePIE.Core.Plugins
 
                 recognitionEngine.SpeechRecognized += (s, e) =>
                 {
-                    var info = recognizerResults[e.Result.Text];
+                    if (recognitionActive)
+                    {
+                        var info = recognizerResults[e.Result.Text];
 
-                    if (e.Result.Confidence >= info.Confidence)
-                        info.Result = true;
+                        if (e.Result.Confidence >= info.Confidence)
+                            info.Result = true;    
+                    }
+                    
                 };
 
             }
@@ -157,6 +167,11 @@ namespace FreePIE.Core.Plugins
         public void selectVoice(string name)
         {
             plugin.SelectVoice(name);
+        }
+
+        public void enableRecognition(bool enable)
+        {
+            plugin.EnableRecognition(enable);
         }
     }
 }


### PR DESCRIPTION
Adds the ability to shut down speech recognition plugin via python.

The problem I ran into was when adding a push to talk voice recognition was that while the push to talk button was not held speech was being recognized and queued internally, and as soon as the push to talk button was pressed all previously said phrases that should not have been recognized would fire.

This change would allow a user to configure speech recognition in a push to talk fashion like this:
```python
if joystick[0].getDown(0):
  if speech.said("form on me"):
    # execute keyboard macro
else:
  speech.disable()
```

Rapidly enabling and disabling the speech recognition engine doesn't seem to have any performance impact.